### PR TITLE
Add basic github racer support

### DIFF
--- a/src/race.py
+++ b/src/race.py
@@ -1,0 +1,34 @@
+import simulator
+import argparse
+import shutil
+import os
+from os import getenv
+import subprocess
+import importlib
+import sys
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", action="append", dest="repos", default=[])
+    parser.add_argument("--pull-location",
+                        default=getenv("RACINGAI_PULL_LOCATION", "/tmp/racingai"))
+    args = parser.parse_args()
+    assert len(args.repos) > 0, "Must provide at least one github repository"
+    # Clone repositories
+    if not os.path.isdir(args.pull_location):
+        assert not os.path.exists(args.pull_location), \
+            f"'{args.pull_location}' exists and is a file"
+        os.mkdir(args.pull_location)
+    sys.path.append(args.pull_location)
+    driver_modules = []
+    original_directory = os.getcwd()
+    os.chdir(args.pull_location)
+    for index, repo in enumerate(args.repos):
+        if os.path.exists(str(index)):
+            shutil.rmtree(str(index))
+        subprocess.call(["git", "clone", repo, str(index)])
+        spec = importlib.util.find_spec(os.path.join(f"{str(index)}.driver"))
+        driver_modules.append(spec.loader.load_module())
+    os.chdir(original_directory)
+    print("STARTING RACE")
+    simulator.race([module.Driver() for module in driver_modules])

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -12,25 +12,22 @@ from drivers.ctq import CTQmk4
 from drivers.disparity import DisparityExtender
 
 #Visualisation
-import pygame,sys
-from LidarVis import *
+from LidarVis import Visualiser, calc_end_pos
 
-# choose your drivers here (1-4)
-drivers = [DisparityExtender()]
-
-# choose your racetrack here (TRACK_1, TRACK_2, TRACK_3, OBSTACLES)
-RACETRACK = 'TRACK_1'
-
-# visualiser
-visualise_lidar = True
-vis_driver_idx = 0 # Which driver do you want to visualise
-
-if __name__ == '__main__':
-    with open('maps/{}.yaml'.format(RACETRACK)) as map_conf_file:
+def race(drivers=[DisparityExtender()],
+         racetrack='TRACK_1',
+         vis_driver_idx=0,
+         visualise_lidar=True):
+    """
+    :param racetrack: (TRACK_1, TRACK_2, TRACK_3, OBSTACLES)
+    :param drivers: A list of classes with a process_lidar
+    function.
+    """
+    with open('maps/{}.yaml'.format(racetrack)) as map_conf_file:
         map_conf = yaml.load(map_conf_file, Loader=yaml.FullLoader)
     scale = map_conf['resolution'] / map_conf['default_resolution']
     starting_angle = map_conf['starting_angle']
-    env = gym.make('f110_gym:f110-v0', map="maps/{}".format(RACETRACK),
+    env = gym.make('f110_gym:f110-v0', map="maps/{}".format(racetrack),
             map_ext=".png", num_agents=len(drivers), disable_env_checker = True)
     # specify starting positions of each agent
     poses = np.array([[-1.25*scale + (i * 0.75*scale), 0., starting_angle] for i in range(len(drivers))])
@@ -64,3 +61,6 @@ if __name__ == '__main__':
         if obs['collisions'].any() == 1.0:
             break
     print('Sim elapsed time:', laptime, 'Real elapsed time:', time.time()-start)
+
+if __name__ == "__main__":
+    race()


### PR DESCRIPTION
This PR adds basic support for pulling driver.py files from github (or any git repository) and having them compete in the gym environment. The syntax is as follows:

```
py race.py --repo GIT_REPOSITORY_1 --repo GIT_REPOSITORY_2
```

In order to do this I have refactored the main body of simulator.py into a race method that can be invoked externally.

Possible means of extension:
- Using `git shortlog -s | cut -f2` to display contributor names before the race startes.
- Having a web frontend to the race.py script.
- Allowing more repository structures to be allowed, e.g. customising where the driver.py file is.