### PR TITLE
Use tempfile library instead of /tmp

### DIFF
--- a/src/race.py
+++ b/src/race.py
@@ -6,12 +6,13 @@ from os import getenv
 import subprocess
 import importlib
 import sys
+import tempfile
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", action="append", dest="repos", default=[])
     parser.add_argument("--pull-location",
-                        default=getenv("RACINGAI_PULL_LOCATION", "/tmp/racingai"))
+                        default=getenv("RACINGAI_PULL_LOCATION", os.path.join(tempfile.gettempdir(), 'racing-ai')))
     args = parser.parse_args()
     assert len(args.repos) > 0, "Must provide at least one github repository"
     # Clone repositories


### PR DESCRIPTION
I was relying on the /tmp directory to exist which will not be the case on windows. This PR uses the tempfile library to get the correct location of the temporary directory for both windows and linux.

